### PR TITLE
chore: fix extractRenderTemplate example format

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Constructs a render method object for the specified template and type.
 ### extractRenderTemplate
 
 ```typescript
-`extractRenderTemplate(renderMethod: RenderMethod)
+extractRenderTemplate(renderMethod: RenderMethod)
 ```
 
 Extracts the template content, fetching from a URL if necessary.


### PR DESCRIPTION
This PR fixes the format of the extractRenderTemplate example.