### PR TITLE
feat: normalise template whitespace

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -33,6 +33,7 @@ describe('Main Index Functions', () => {
     MockedRenderMethodFactory.mockClear();
     MockedTemplatingEngineFactory.mockClear();
     mockedUtils.removeLineBreaks.mockClear();
+    mockedUtils.normaliseWhitespace.mockClear();
 
     mockRenderMethodProvider = {
       construct: jest.fn(),
@@ -51,8 +52,9 @@ describe('Main Index Functions', () => {
   });
 
   describe('constructRenderMethod', () => {
-    const template = 'template\nwith\nbreaks';
-    const cleanedTemplate = 'templatewithbreaks';
+    const template = 'template\nwith\nbreaks   and   spaces';
+    const templateWithoutLineBreaks = 'templatewithbreaks   and   spaces';
+    const cleanedTemplate = 'templatewithbreaks and spaces';
     const type = RenderMethodType.RenderTemplate2024;
     const extra = { key: 'value' };
     const expectedResult: RenderMethod = {
@@ -63,15 +65,28 @@ describe('Main Index Functions', () => {
     };
 
     it('should call removeLineBreaks with the template', () => {
-      mockedUtils.removeLineBreaks.mockReturnValue(cleanedTemplate);
+      mockedUtils.removeLineBreaks.mockReturnValue(templateWithoutLineBreaks);
+      mockedUtils.normaliseWhitespace.mockReturnValue(cleanedTemplate);
       mockRenderMethodProvider.construct.mockReturnValue(expectedResult);
 
       constructRenderMethod(template, type, extra);
       expect(mockedUtils.removeLineBreaks).toHaveBeenCalledWith(template);
     });
 
+    it('should call normaliseWhitespace with the result of removeLineBreaks', () => {
+      mockedUtils.removeLineBreaks.mockReturnValue(templateWithoutLineBreaks);
+      mockedUtils.normaliseWhitespace.mockReturnValue(cleanedTemplate);
+      mockRenderMethodProvider.construct.mockReturnValue(expectedResult);
+
+      constructRenderMethod(template, type, extra);
+      expect(mockedUtils.normaliseWhitespace).toHaveBeenCalledWith(
+        templateWithoutLineBreaks,
+      );
+    });
+
     it('should create RenderMethodFactory and call createRenderMethod', () => {
-      mockedUtils.removeLineBreaks.mockReturnValue(cleanedTemplate);
+      mockedUtils.removeLineBreaks.mockReturnValue(templateWithoutLineBreaks);
+      mockedUtils.normaliseWhitespace.mockReturnValue(cleanedTemplate);
       mockRenderMethodProvider.construct.mockReturnValue(expectedResult);
 
       constructRenderMethod(template, type, extra);
@@ -82,7 +97,8 @@ describe('Main Index Functions', () => {
     });
 
     it('should call construct on the created render method provider', () => {
-      mockedUtils.removeLineBreaks.mockReturnValue(cleanedTemplate);
+      mockedUtils.removeLineBreaks.mockReturnValue(templateWithoutLineBreaks);
+      mockedUtils.normaliseWhitespace.mockReturnValue(cleanedTemplate);
       mockRenderMethodProvider.construct.mockReturnValue(expectedResult);
 
       constructRenderMethod(template, type, extra);
@@ -93,7 +109,8 @@ describe('Main Index Functions', () => {
     });
 
     it('should return the result from the render method provider construct', () => {
-      mockedUtils.removeLineBreaks.mockReturnValue(cleanedTemplate);
+      mockedUtils.removeLineBreaks.mockReturnValue(templateWithoutLineBreaks);
+      mockedUtils.normaliseWhitespace.mockReturnValue(cleanedTemplate);
       mockRenderMethodProvider.construct.mockReturnValue(expectedResult);
 
       const result = constructRenderMethod(template, type, extra);

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { TemplateFetchError } from '../errors';
-import { fetchTemplate, removeLineBreaks } from '../utils';
+import { fetchTemplate, normaliseWhitespace, removeLineBreaks } from '../utils';
 
 describe('Utility Functions', () => {
   beforeEach(() => {
@@ -84,6 +84,32 @@ describe('Utility Functions', () => {
 
     it('should handle mixed content', () => {
       expect(removeLineBreaks('start\nmiddle\nend')).toBe('startmiddleend');
+    });
+  });
+
+  describe('normaliseWhitespace', () => {
+    it('should replace multiple spaces with a single space', () => {
+      expect(normaliseWhitespace('hello    world')).toBe('hello world');
+    });
+
+    it('should replace tabs with a single space', () => {
+      expect(normaliseWhitespace('hello\tworld')).toBe('hello world');
+    });
+
+    it('should replace mixed whitespace with a single space', () => {
+      expect(normaliseWhitespace('hello \t \n world')).toBe('hello world');
+    });
+
+    it('should handle leading and trailing whitespace', () => {
+      expect(normaliseWhitespace('  hello world  ')).toBe(' hello world ');
+    });
+
+    it('should handle empty string', () => {
+      expect(normaliseWhitespace('')).toBe('');
+    });
+
+    it('should handle string with only whitespace', () => {
+      expect(normaliseWhitespace('   \t\n   ')).toBe(' ');
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { RenderMethodFactory } from './render_methods/factory';
 import { TemplatingEngineFactory } from './templating_engines/factory';
 import { RenderMethod, RenderMethodType, TemplatingEngineType } from './types';
-import { removeLineBreaks } from './utils';
+import { normaliseWhitespace, removeLineBreaks } from './utils';
 
 export * from './errors';
 export * from './types';
@@ -11,7 +11,7 @@ export function constructRenderMethod(
   renderMethodType: RenderMethodType,
   extra: Record<string, unknown> = {},
 ): RenderMethod {
-  const cleanedTemplate = removeLineBreaks(template);
+  const cleanedTemplate = normaliseWhitespace(removeLineBreaks(template));
 
   const renderMethodFactory = new RenderMethodFactory();
   const renderMethod = renderMethodFactory.createRenderMethod(renderMethodType);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,3 +13,7 @@ export const fetchTemplate = async (url: string) => {
 export const removeLineBreaks = (str: string) => {
   return str.replace(/\n/g, '');
 };
+
+export const normaliseWhitespace = (str: string) => {
+  return str.replace(/\s+/g, ' ');
+};


### PR DESCRIPTION
This PR normalises whitespace in render templates by collapsing consecutive whitespace into a single space when constructing the render method object.