### PR TITLE
feat: enhance removeLineBreaks to handle \r and consecutive line breaks

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -85,6 +85,26 @@ describe('Utility Functions', () => {
     it('should handle mixed content', () => {
       expect(removeLineBreaks('start\nmiddle\nend')).toBe('startmiddleend');
     });
+
+    it('should remove carriage returns', () => {
+      expect(removeLineBreaks('hello\rworld')).toBe('helloworld');
+    });
+
+    it('should remove Windows-style line endings (CRLF)', () => {
+      expect(removeLineBreaks('hello\r\nworld')).toBe('helloworld');
+    });
+
+    it('should remove multiple consecutive mixed line breaks', () => {
+      expect(removeLineBreaks('hello\n\n\rworld\r\n\r\nmiddle')).toBe(
+        'helloworldmiddle',
+      );
+    });
+
+    it('should treat consecutive line breaks as a single replacement', () => {
+      expect(removeLineBreaks('line\n\n\nbreak')).toBe('linebreak');
+      expect(removeLineBreaks('line\r\r\rbreak')).toBe('linebreak');
+      expect(removeLineBreaks('line\r\n\r\nbreak')).toBe('linebreak');
+    });
   });
 
   describe('normaliseWhitespace', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export const fetchTemplate = async (url: string) => {
 };
 
 export const removeLineBreaks = (str: string) => {
-  return str.replace(/\n/g, '');
+  return str.replace(/[\n\r]+/g, '');
 };
 
 export const normaliseWhitespace = (str: string) => {


### PR DESCRIPTION
This PR enhances the removeLineBreaks utility by updating its regex from `/\n/g` to `/[\n\r]+/g`.

The change:
- Adds support for removing \r (carriage return) in addition to \n (line feed).
- Handles consecutive line breaks (e.g., \r\n, \n\n) using the + quantifier.
- Improves robustness for cross-platform text inputs, such as Windows-style \r\n line endings.