### PR TITLE
ci: fix changelog manifest version bump

### DIFF
--- a/.github/workflows/release-please-config.json
+++ b/.github/workflows/release-please-config.json
@@ -9,6 +9,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "separate-pull-requests": false,
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
This PR updates the changelog configuration in an attempt to force the release please GitHub action to bump the manifest version.

See issue [#2172](https://github.com/googleapis/release-please/issues/2172)