### PR TITLE
ci: remove node workspace plugin

### DIFF
--- a/.github/workflows/release-please-config.json
+++ b/.github/workflows/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["node-workspace", "sentence-case"],
+  "plugins": ["sentence-case"],
   "always-update": true,
   "skip-github-release": true,
   "pull-request-title-pattern": "chore: bump version to ${version} and update changelog",
@@ -9,7 +9,6 @@
   "packages": {
     ".": {
       "release-type": "node",
-      "separate-pull-requests": false,
       "changelog-sections": [
         {
           "type": "feat",


### PR DESCRIPTION
This PR removes the node-workspace plugin from the release please action config as it was interfering with bumping the version of the manifest file.