### PR TITLE
feat(render-method-2024)!: align RenderTemplate2024 with downstream renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Constructs a render method object for the specified template and type.
 
 - `template`: The template string or empty if using a URL.
 - `renderMethodType`: Either `RenderTemplate2024` or `WebRenderingTemplate2022`.
-- `extra`: Optional metadata (e.g., `url` or `mediaQuery`).
+- `extra`: Optional metadata. For `RenderTemplate2024` the supported keys are `name`, `mediaQuery`, `url`, `mediaType`, and `digestMultibase`. Empty or non-string values are omitted from the constructed render method rather than emitted as empty strings.
 
 ### extractRenderTemplate
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -58,10 +58,8 @@ describe('Main Index Functions', () => {
     const type = RenderMethodType.RenderTemplate2024;
     const extra = { key: 'value' };
     const expectedResult: RenderMethod = {
-      type: RenderMethodType.RenderTemplate2024,
+      type: [RenderMethodType.RenderTemplate2024],
       template: cleanedTemplate,
-      mediaQuery: '',
-      url: '',
     };
 
     it('should call removeLineBreaks with the template', () => {
@@ -120,12 +118,12 @@ describe('Main Index Functions', () => {
 
   describe('extractRenderTemplate', () => {
     const renderMethodObject: RenderMethod = {
-      type: RenderMethodType.RenderTemplate2024,
+      type: [RenderMethodType.RenderTemplate2024],
       template: 'some template',
     };
     const expectedTemplate = 'extracted template content';
 
-    it('should create RenderMethodFactory and call createRenderMethod', async () => {
+    it('should create RenderMethodFactory and call createRenderMethod with the resolved render method type', async () => {
       mockRenderMethodProvider.extractTemplate.mockResolvedValue(
         expectedTemplate,
       );
@@ -134,7 +132,55 @@ describe('Main Index Functions', () => {
       expect(MockedRenderMethodFactory).toHaveBeenCalledTimes(1);
       expect(
         MockedRenderMethodFactory.prototype.createRenderMethod,
-      ).toHaveBeenCalledWith(renderMethodObject.type);
+      ).toHaveBeenCalledWith(RenderMethodType.RenderTemplate2024);
+    });
+
+    it('should resolve the render method type from a `type` array containing additional values', async () => {
+      mockRenderMethodProvider.extractTemplate.mockResolvedValue(
+        expectedTemplate,
+      );
+
+      await extractRenderTemplate({
+        type: ['SomeOtherType', RenderMethodType.RenderTemplate2024],
+        template: 'some template',
+      });
+      expect(
+        MockedRenderMethodFactory.prototype.createRenderMethod,
+      ).toHaveBeenCalledWith(RenderMethodType.RenderTemplate2024);
+    });
+
+    it('should pass a non-array `type` through unchanged to the factory', async () => {
+      mockRenderMethodProvider.extractTemplate.mockResolvedValue(
+        expectedTemplate,
+      );
+
+      await extractRenderTemplate({
+        type: RenderMethodType.WebRenderingTemplate2022,
+        template: 'some template',
+      });
+      expect(
+        MockedRenderMethodFactory.prototype.createRenderMethod,
+      ).toHaveBeenCalledWith(RenderMethodType.WebRenderingTemplate2022);
+    });
+
+    it('should throw UnsupportedRenderMethodError including the unsupported entries when no `type` entry is supported', async () => {
+      await expect(
+        extractRenderTemplate({
+          type: ['UnknownType', 'AnotherUnknown'],
+          template: 'some template',
+        } as unknown as RenderMethod),
+      ).rejects.toThrow(
+        'Unsupported render method: UnknownType, AnotherUnknown',
+      );
+    });
+
+    it('should throw UnsupportedRenderMethodError with an `<empty>` indicator when `type` is an empty array', async () => {
+      await expect(
+        extractRenderTemplate({
+          type: [],
+          template: 'some template',
+        } as unknown as RenderMethod),
+      ).rejects.toThrow('Unsupported render method: <empty>');
     });
 
     it('should call extractTemplate on the created render method provider', async () => {

--- a/src/__tests__/render_methods/render-method-2024.test.ts
+++ b/src/__tests__/render_methods/render-method-2024.test.ts
@@ -25,23 +25,84 @@ describe('RenderMethod2024', () => {
   });
 
   describe('construct', () => {
-    it('should construct a RenderTemplate2024 object correctly', () => {
+    it('should construct a RenderTemplate2024 object with `type` as an array containing the render method type', () => {
+      const result = renderMethod.construct(templateContent, extraData);
+      expect(result.type).toEqual([RenderMethodType.RenderTemplate2024]);
+    });
+
+    it('should include template and provided extra fields when present', () => {
       const result = renderMethod.construct(templateContent, extraData);
       expect(result).toEqual({
-        type: RenderMethodType.RenderTemplate2024,
+        type: [RenderMethodType.RenderTemplate2024],
         template: templateContent,
         mediaQuery: extraData.mediaQuery,
         url: extraData.url,
       });
     });
 
-    it('should use default values if extra data is missing', () => {
+    it('should accept all spec-defined optional fields via extra', () => {
+      const fullExtra = {
+        name: 'Display Name',
+        mediaQuery: 'print',
+        url: 'http://example.com/t.html',
+        mediaType: 'text/html',
+        digestMultibase: 'zQmExampleHash',
+      };
+      const result = renderMethod.construct(templateContent, fullExtra);
+      expect(result).toEqual({
+        type: [RenderMethodType.RenderTemplate2024],
+        template: templateContent,
+        ...fullExtra,
+      });
+    });
+
+    it('should omit optional fields that are not provided rather than emitting empty strings', () => {
       const result = renderMethod.construct(templateContent, {});
       expect(result).toEqual({
-        type: RenderMethodType.RenderTemplate2024,
+        type: [RenderMethodType.RenderTemplate2024],
         template: templateContent,
+      });
+      expect(result).not.toHaveProperty('mediaQuery');
+      expect(result).not.toHaveProperty('url');
+      expect(result).not.toHaveProperty('name');
+      expect(result).not.toHaveProperty('mediaType');
+      expect(result).not.toHaveProperty('digestMultibase');
+    });
+
+    it('should omit optional fields that are explicitly empty strings', () => {
+      const result = renderMethod.construct(templateContent, {
+        name: '',
         mediaQuery: '',
         url: '',
+        mediaType: '',
+        digestMultibase: '',
+      });
+      expect(result).toEqual({
+        type: [RenderMethodType.RenderTemplate2024],
+        template: templateContent,
+      });
+    });
+
+    it('should omit `template` when it is an empty string (URL-only case)', () => {
+      const result = renderMethod.construct('', {
+        url: 'http://example.com/t.html',
+      });
+      expect(result).toEqual({
+        type: [RenderMethodType.RenderTemplate2024],
+        url: 'http://example.com/t.html',
+      });
+      expect(result).not.toHaveProperty('template');
+    });
+
+    it('should ignore non-string values supplied via extra', () => {
+      const result = renderMethod.construct(templateContent, {
+        name: 42,
+        mediaQuery: null,
+        url: undefined,
+      } as unknown as Record<string, unknown>);
+      expect(result).toEqual({
+        type: [RenderMethodType.RenderTemplate2024],
+        template: templateContent,
       });
     });
   });

--- a/src/errors/render-methods.ts
+++ b/src/errors/render-methods.ts
@@ -1,7 +1,7 @@
 import { RenderMethodType } from '../types';
 
 export class UnsupportedRenderMethodError extends Error {
-  constructor(method: RenderMethodType) {
+  constructor(method: RenderMethodType | string) {
     super(
       `Unsupported render method: ${method}. Supported methods are: ${Object.values(
         RenderMethodType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
+import { UnsupportedRenderMethodError } from './errors';
 import { RenderMethodFactory } from './render_methods/factory';
 import { TemplatingEngineFactory } from './templating_engines/factory';
-import { RenderMethod, RenderMethodType, TemplatingEngineType } from './types';
+import {
+  RenderMethod,
+  RenderMethodType,
+  TemplatingEngineType,
+  supportedRenderMethods,
+} from './types';
 import { normaliseWhitespace, removeLineBreaks } from './utils';
 
 export * from './errors';
@@ -22,7 +28,7 @@ export function constructRenderMethod(
 export const extractRenderTemplate = async (
   renderMethodObject: RenderMethod,
 ): Promise<string> => {
-  const renderMethodType = renderMethodObject.type;
+  const renderMethodType = resolveRenderMethodType(renderMethodObject.type);
 
   const renderMethodFactory = new RenderMethodFactory();
   const renderMethod = renderMethodFactory.createRenderMethod(renderMethodType);
@@ -30,6 +36,26 @@ export const extractRenderTemplate = async (
   const renderTemplate = await renderMethod.extractTemplate(renderMethodObject);
 
   return renderTemplate;
+};
+
+const resolveRenderMethodType = (
+  type: RenderMethod['type'],
+): RenderMethodType => {
+  if (!Array.isArray(type)) {
+    return type;
+  }
+
+  const match = type.find((entry): entry is RenderMethodType =>
+    (supportedRenderMethods as readonly string[]).includes(entry),
+  );
+
+  if (!match) {
+    throw new UnsupportedRenderMethodError(
+      type.length === 0 ? '<empty>' : type.join(', '),
+    );
+  }
+
+  return match;
 };
 
 export const populateTemplate = (

--- a/src/render_methods/render-method-2024.ts
+++ b/src/render_methods/render-method-2024.ts
@@ -9,11 +9,16 @@ import {
 import { fetchTemplate } from '../utils';
 
 export const defaultRenderMethod2024: RenderTemplate2024 = {
-  type: RenderMethodType.RenderTemplate2024,
-  mediaQuery: '',
-  template: '',
-  url: '',
+  type: [RenderMethodType.RenderTemplate2024],
 };
+
+const OPTIONAL_FIELDS = [
+  'name',
+  'mediaQuery',
+  'url',
+  'mediaType',
+  'digestMultibase',
+] as const;
 
 export class RenderMethod2024 implements RenderMethodProvider {
   private readonly _formatter: Formatter;
@@ -26,12 +31,22 @@ export class RenderMethod2024 implements RenderMethodProvider {
     template: string,
     extra: Record<string, unknown>,
   ): RenderTemplate2024 {
-    return {
-      type: RenderMethodType.RenderTemplate2024,
-      mediaQuery: (extra.mediaQuery || '') as string,
-      template,
-      url: (extra.url || '') as string,
+    const result: RenderTemplate2024 = {
+      type: [RenderMethodType.RenderTemplate2024],
     };
+
+    if (template) {
+      result.template = template;
+    }
+
+    for (const field of OPTIONAL_FIELDS) {
+      const value = extra[field];
+      if (typeof value === 'string' && value !== '') {
+        result[field] = value;
+      }
+    }
+
+    return result;
   }
 
   async extractTemplate(renderMethod: RenderMethod): Promise<string> {

--- a/src/types/render-methods.ts
+++ b/src/types/render-methods.ts
@@ -9,10 +9,13 @@ export const supportedRenderMethods = [
 ] as const;
 
 export interface RenderTemplate2024 {
-  type: RenderMethodType.RenderTemplate2024;
+  type: string[];
+  name?: string;
   mediaQuery?: string;
   template?: string;
   url?: string;
+  mediaType?: string;
+  digestMultibase?: string;
 }
 
 export interface WebRenderingTemplate2022 {


### PR DESCRIPTION
This PR aligns the `RenderTemplate2024` interface and provider with the shape already produced and consumed by the downstream vckit renderer (`packages/renderer/src/providers/render-template-2024.ts`), so render methods built via `constructRenderMethod` round-trip cleanly through the renderer with no missing fields.

The renderer reads `name`, `mediaType`, and `digestMultibase`, and a `type` array containing `"RenderTemplate2024"`. The previous interface only modelled `mediaQuery`, `template`, and `url`, and emitted unset optional fields as empty strings, neither of which match what the renderer expects.

Closes #18

### Breaking changes

- `RenderTemplate2024.type` is now `string[]` rather than the literal `RenderMethodType.RenderTemplate2024`. Direct consumers of the type (anyone reading `renderMethod.type === 'RenderTemplate2024'`) must update to `renderMethod.type.includes('RenderTemplate2024')`.
- `RenderMethod2024.construct` no longer emits unset optional fields. Code that relies on `mediaQuery: ''` or `url: ''` always being present must check for the property before reading it.

### Additions

- New optional fields on `RenderTemplate2024`: `name`, `mediaType`, `digestMultibase`. All are accepted via the `extra` argument of `constructRenderMethod` and only emitted when supplied as non-empty strings.
- `extractRenderTemplate` resolves the discriminator from either string or `string[]` `type` values, throwing `UnsupportedRenderMethodError` (with diagnostic detail for empty or unsupported arrays) when no supported entry is present.

### Out of scope (potential follow-ups)

- Tightening `type` to a tuple form (`[RenderMethodType.RenderTemplate2024, ...string[]]`) to encode the "must contain" invariant in the type system.
- Splitting `RenderTemplate2024` into Input vs Emitted variants to express the producer/consumer asymmetry.
- Validating the discriminator inside `constructRenderMethod` (currently only the extract path validates).

## Test plan
- [x] `type` is emitted as an array containing `"RenderTemplate2024"`
- [x] `name`, `mediaType`, and `digestMultibase` are accepted via `extra` and round-tripped onto the constructed render method
- [x] Optional fields supplied as `undefined`, missing, empty string, or non-string values are omitted from the constructed render method (no empty-string emission)
- [x] `template` is omitted when empty (URL-only construction)
- [x] `extractRenderTemplate` resolves the render method type from a `string[]` discriminator, including arrays with additional entries
- [x] `extractRenderTemplate` passes through a non-array `type` unchanged for `WebRenderingTemplate2022`
- [x] `extractRenderTemplate` throws `UnsupportedRenderMethodError` with the joined unsupported entries, and with `<empty>` when the array is empty
- [x] `yarn build`, `yarn test`, `yarn lint`, and `yarn format` all pass