### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and the version numbers follow [semantic versioning](https://semver.org/).
 The package ships via the `v<X.Y.Z>` tag-triggered publish workflow described
 in [ADR 001](./docs/adrs/001-trunk-based-development-and-tag-triggered-releases.md).
 
+## [2.1.0] - 2026-05-15
+
+### Added
+
+- `constructRenderMethodAsync`: asynchronous counterpart to
+  `constructRenderMethod` that auto-fills `digestMultibase` for
+  `RenderTemplate2024` outputs when `extra.url` is a non-empty string, the
+  source `template` is non-empty, and the caller has not pre-supplied a
+  `digestMultibase`. The synchronous `constructRenderMethod` is unchanged.
+- `generateDigestMultibase(content, opts?)`: primitive that hashes the UTF-8
+  bytes of `content` and returns a multibase-encoded multihash string.
+  Defaults to `sha2-256` and `base58btc`; both configurable. Built on
+  [`@uncefact/untp-utils`](https://www.npmjs.com/package/@uncefact/untp-utils).
+- `DEFAULT_DIGEST_ALGORITHM` and `DEFAULT_DIGEST_BASE` exported constants for
+  callers that want to be explicit about the defaults.
+
+### Changed
+
+- The Jest config now transforms `@uncefact/untp-utils` and `multiformats`
+  via `transformIgnorePatterns`, with targeted `moduleNameMapper` entries
+  for the `multiformats` subpaths used by the new primitive. Existing tests
+  are unaffected.
+
 ## [2.0.0] - 2026-05-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -94,6 +94,39 @@ Constructs a render method object for the specified template and type.
 - `renderMethodType`: Either `RenderTemplate2024` or `WebRenderingTemplate2022`.
 - `extra`: Optional metadata. For `RenderTemplate2024` the supported keys are `name`, `mediaQuery`, `url`, `mediaType`, and `digestMultibase`. Empty or non-string values are omitted from the constructed render method rather than emitted as empty strings.
 
+### constructRenderMethodAsync
+
+```typescript
+constructRenderMethodAsync(template: string, renderMethodType: RenderMethodType, extra?: Record<string, unknown>): Promise<RenderMethod>
+```
+
+Asynchronous counterpart to `constructRenderMethod`. Behaves identically except that, for `RenderTemplate2024` outputs, it auto-fills `digestMultibase` from the source template bytes when a `url` is supplied and the caller has not already provided a digest.
+
+`digestMultibase` is gated on the presence of `url`: it only adds value when the template is hosted remotely, since an inline `template` is already covered by the signed credential.
+
+```typescript
+import {
+  constructRenderMethodAsync,
+  RenderMethodType,
+} from '@pyx-industries/vc-render-template-utils';
+
+const renderMethod = await constructRenderMethodAsync(
+  '<div>Hello, {{name}}!</div>',
+  RenderMethodType.RenderTemplate2024,
+  { url: 'https://example.com/template.html' },
+);
+
+// renderMethod.digestMultibase === 'z...' (sha2-256 + base58btc by default)
+```
+
+### generateDigestMultibase
+
+```typescript
+generateDigestMultibase(content: string, opts?: { algorithm?: HashAlgorithm; base?: MultibaseEncoding }): Promise<string>
+```
+
+Hashes the UTF-8 bytes of `content` and returns a multibase-encoded multihash string suitable for `digestMultibase` fields. Defaults to `sha2-256` and `base58btc`; see [@uncefact/untp-utils](https://www.npmjs.com/package/@uncefact/untp-utils) for the supported algorithms and encodings.
+
 ### extractRenderTemplate
 
 ```typescript

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,8 +13,8 @@ A new asynchronous constructor, `constructRenderMethodAsync`, mirrors
 `RenderTemplate2024` outputs whenever a `url` is supplied and the template
 is non-empty. Existing callers that already compute their own
 `digestMultibase` (or that do not want one) are unaffected: the
-synchronous `constructRenderMethod` is unchanged, and a caller-supplied
-`digestMultibase` is preserved verbatim.
+synchronous `constructRenderMethod` is unchanged, and a non-empty
+caller-supplied `digestMultibase` is preserved verbatim.
 
 The gating reflects the spec semantics. A `digestMultibase` only adds
 value when the template is hosted remotely, because the signed credential

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,38 @@ User-facing release notes for `@pyx-industries/vc-render-template-utils`.
 Each entry frames what the release lets you do, not how it does it. For a
 technical, per-change record see [CHANGELOG.md](./CHANGELOG.md).
 
+## 2.1.0 - 2026-05-15
+
+### `digestMultibase` is generated for you when you opt in
+
+A new asynchronous constructor, `constructRenderMethodAsync`, mirrors
+`constructRenderMethod` but auto-fills `digestMultibase` for
+`RenderTemplate2024` outputs whenever a `url` is supplied and the template
+is non-empty. Existing callers that already compute their own
+`digestMultibase` (or that do not want one) are unaffected: the
+synchronous `constructRenderMethod` is unchanged, and a caller-supplied
+`digestMultibase` is preserved verbatim.
+
+The gating reflects the spec semantics. A `digestMultibase` only adds
+value when the template is hosted remotely, because the signed credential
+itself already covers an inline template. The presence of `url` is
+treated as the caller's declaration of remote intent, so the digest is
+only emitted when the remote path is the source of truth.
+
+### A primitive you can reach for directly
+
+For consumers that need a multibase-encoded multihash outside the render
+method flow, `generateDigestMultibase(content, opts?)` is exported as a
+standalone primitive. Defaults to `sha2-256` plus `base58btc`, the
+conventional UNTP and W3C VC choices. The companion constants
+`DEFAULT_DIGEST_ALGORITHM` and `DEFAULT_DIGEST_BASE` are exported for
+callers that want to write the defaults out explicitly.
+
+The implementation builds on
+[`@uncefact/untp-utils`](https://www.npmjs.com/package/@uncefact/untp-utils),
+so the algorithm and encoding choices live in a single place across the
+UNTP ecosystem.
+
 ## 2.0.0 - 2026-05-01
 
 ### `RenderTemplate2024` now matches the downstream renderer

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,6 +9,13 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!(@uncefact/untp-utils|multiformats)/)',
   ],
+  // The mappers below reach into multiformats' compiled output to resolve the
+  // subpaths used by @uncefact/untp-utils under a CJS Jest setup. multiformats
+  // ships its public API via its `exports` map with only an `import` condition,
+  // which CJS Jest cannot follow. These mappers are coupled to the internal
+  // dist layout, so a multiformats release that reshapes `dist/src/...` will
+  // need updates here. A future move to an ESM Jest setup removes this
+  // coupling entirely.
   moduleNameMapper: {
     '^multiformats/hashes/digest$':
       '<rootDir>/node_modules/multiformats/dist/src/hashes/digest.js',

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,23 @@ module.exports = {
   testEnvironment: 'node',
   setupFiles: ['<rootDir>/jest.setup.cjs'],
   testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(@uncefact/untp-utils|multiformats)/)',
+  ],
+  moduleNameMapper: {
+    '^multiformats/hashes/digest$':
+      '<rootDir>/node_modules/multiformats/dist/src/hashes/digest.js',
+    '^multiformats/hashes/sha2$':
+      '<rootDir>/node_modules/multiformats/dist/src/hashes/sha2.js',
+    '^multiformats/bases/base58$':
+      '<rootDir>/node_modules/multiformats/dist/src/bases/base58.js',
+    '^multiformats/bases/base64$':
+      '<rootDir>/node_modules/multiformats/dist/src/bases/base64.js',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   coverageThreshold: {
     global: {
       branches: 80,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@uncefact/untp-utils": "^0.1.0",
     "handlebars": "^4.7.8",
     "js-beautify": "^1.15.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyx-industries/vc-render-template-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A lightweight utility library for constructing, extracting and rendering verifiable credential render templates.",
   "repository": {
     "type": "git",

--- a/src/__tests__/construct-render-method-async.test.ts
+++ b/src/__tests__/construct-render-method-async.test.ts
@@ -32,6 +32,37 @@ describe('constructRenderMethodAsync', () => {
       expect(result.digestMultibase).toBeUndefined();
     });
 
+    it('omits digestMultibase when url is an empty string', async () => {
+      const result = (await constructRenderMethodAsync(
+        template,
+        RenderMethodType.RenderTemplate2024,
+        { url: '' },
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBeUndefined();
+    });
+
+    it('omits digestMultibase when url is a non-string value', async () => {
+      const result = (await constructRenderMethodAsync(
+        template,
+        RenderMethodType.RenderTemplate2024,
+        { url: 123 as unknown as string },
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBeUndefined();
+    });
+
+    it('regenerates digestMultibase when caller supplies an empty string', async () => {
+      const result = (await constructRenderMethodAsync(
+        template,
+        RenderMethodType.RenderTemplate2024,
+        { url, digestMultibase: '' },
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBeDefined();
+      expect(result.digestMultibase).not.toBe('');
+    });
+
     it('omits digestMultibase when template is empty even if url is set', async () => {
       const result = (await constructRenderMethodAsync(
         '',

--- a/src/__tests__/construct-render-method-async.test.ts
+++ b/src/__tests__/construct-render-method-async.test.ts
@@ -1,0 +1,84 @@
+import { MultibaseDigest } from '@uncefact/untp-utils';
+
+import { constructRenderMethodAsync } from '../index';
+import { RenderMethodType, RenderTemplate2024 } from '../types';
+
+describe('constructRenderMethodAsync', () => {
+  const template = '<div>{{name}}</div>';
+  const url = 'https://example.com/template.html';
+
+  describe('RenderTemplate2024', () => {
+    it('auto-generates digestMultibase from the template bytes when url is set', async () => {
+      const result = (await constructRenderMethodAsync(
+        template,
+        RenderMethodType.RenderTemplate2024,
+        { url },
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBeDefined();
+      const parsed = MultibaseDigest.fromString(result.digestMultibase!);
+      await expect(
+        parsed.verify(new TextEncoder().encode(template)),
+      ).resolves.toBe(true);
+    });
+
+    it('omits digestMultibase when url is not set', async () => {
+      const result = (await constructRenderMethodAsync(
+        template,
+        RenderMethodType.RenderTemplate2024,
+        {},
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBeUndefined();
+    });
+
+    it('omits digestMultibase when template is empty even if url is set', async () => {
+      const result = (await constructRenderMethodAsync(
+        '',
+        RenderMethodType.RenderTemplate2024,
+        { url },
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBeUndefined();
+    });
+
+    it('preserves a caller-supplied digestMultibase rather than overwriting it', async () => {
+      const callerSupplied = 'zCallerSuppliedValue';
+
+      const result = (await constructRenderMethodAsync(
+        template,
+        RenderMethodType.RenderTemplate2024,
+        { url, digestMultibase: callerSupplied },
+      )) as RenderTemplate2024;
+
+      expect(result.digestMultibase).toBe(callerSupplied);
+    });
+
+    it('still passes through the cleaned template, mediaQuery, and url', async () => {
+      const result = (await constructRenderMethodAsync(
+        '<div>\n   {{name}}   </div>',
+        RenderMethodType.RenderTemplate2024,
+        { url, mediaQuery: 'print' },
+      )) as RenderTemplate2024;
+
+      expect(result.type).toEqual([RenderMethodType.RenderTemplate2024]);
+      expect(result.template).toBe('<div> {{name}} </div>');
+      expect(result.url).toBe(url);
+      expect(result.mediaQuery).toBe('print');
+    });
+  });
+
+  describe('WebRenderingTemplate2022', () => {
+    it('returns a result identical to the sync constructRenderMethod', async () => {
+      const result = await constructRenderMethodAsync(
+        template,
+        RenderMethodType.WebRenderingTemplate2022,
+      );
+
+      expect(result).toEqual({
+        type: RenderMethodType.WebRenderingTemplate2022,
+        template,
+      });
+    });
+  });
+});

--- a/src/__tests__/digest/multibase.test.ts
+++ b/src/__tests__/digest/multibase.test.ts
@@ -71,4 +71,14 @@ describe('generateDigestMultibase', () => {
     const b = await generateDigestMultibase('two');
     expect(a).not.toBe(b);
   });
+
+  it('hashes the UTF-8 byte representation of non-ASCII content', async () => {
+    const nonAscii = 'café au lait \u{1F4A1}';
+    const encoded = await generateDigestMultibase(nonAscii);
+    const parsed = MultibaseDigest.fromString(encoded);
+
+    await expect(
+      parsed.verify(new TextEncoder().encode(nonAscii)),
+    ).resolves.toBe(true);
+  });
 });

--- a/src/__tests__/digest/multibase.test.ts
+++ b/src/__tests__/digest/multibase.test.ts
@@ -1,0 +1,74 @@
+import { MultibaseDigest } from '@uncefact/untp-utils';
+
+import { generateDigestMultibase } from '../../digest/multibase';
+
+describe('generateDigestMultibase', () => {
+  const content = '<div>{{name}}</div>';
+
+  it('defaults to a base58btc-encoded sha2-256 digest', async () => {
+    const encoded = await generateDigestMultibase(content);
+
+    expect(encoded.startsWith('z')).toBe(true);
+
+    const parsed = MultibaseDigest.fromString(encoded);
+    expect(parsed.algorithm).toBe('sha2-256');
+    expect(parsed.base).toBe('base58btc');
+  });
+
+  it('produces a digest that verifies against the original content bytes', async () => {
+    const encoded = await generateDigestMultibase(content);
+    const parsed = MultibaseDigest.fromString(encoded);
+
+    await expect(
+      parsed.verify(new TextEncoder().encode(content)),
+    ).resolves.toBe(true);
+  });
+
+  it('supports overriding the hash algorithm', async () => {
+    const encoded = await generateDigestMultibase(content, {
+      algorithm: 'sha2-512',
+    });
+
+    const parsed = MultibaseDigest.fromString(encoded);
+    expect(parsed.algorithm).toBe('sha2-512');
+  });
+
+  it('supports overriding the multibase encoding', async () => {
+    const encoded = await generateDigestMultibase(content, {
+      base: 'base64',
+    });
+
+    expect(encoded.startsWith('m')).toBe(true);
+
+    const parsed = MultibaseDigest.fromString(encoded);
+    expect(parsed.base).toBe('base64');
+  });
+
+  it('throws on an unsupported algorithm', async () => {
+    await expect(
+      generateDigestMultibase(content, {
+        algorithm: 'md5' as never,
+      }),
+    ).rejects.toThrow(/Unsupported hash algorithm/);
+  });
+
+  it('throws on an unsupported multibase encoding', async () => {
+    await expect(
+      generateDigestMultibase(content, {
+        base: 'base32' as never,
+      }),
+    ).rejects.toThrow(/Unsupported multibase encoding/);
+  });
+
+  it('produces identical output for identical content', async () => {
+    const a = await generateDigestMultibase(content);
+    const b = await generateDigestMultibase(content);
+    expect(a).toBe(b);
+  });
+
+  it('produces different output for different content', async () => {
+    const a = await generateDigestMultibase('one');
+    const b = await generateDigestMultibase('two');
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/digest/index.ts
+++ b/src/digest/index.ts
@@ -1,4 +1,6 @@
 export {
+  DEFAULT_DIGEST_ALGORITHM,
+  DEFAULT_DIGEST_BASE,
   generateDigestMultibase,
   type GenerateDigestMultibaseOptions,
 } from './multibase';

--- a/src/digest/index.ts
+++ b/src/digest/index.ts
@@ -1,0 +1,4 @@
+export {
+  generateDigestMultibase,
+  type GenerateDigestMultibaseOptions,
+} from './multibase';

--- a/src/digest/multibase.ts
+++ b/src/digest/multibase.ts
@@ -1,0 +1,55 @@
+import {
+  HashAlgorithm,
+  MultibaseDigest,
+  MultibaseEncoding,
+} from '@uncefact/untp-utils';
+
+/**
+ * Options accepted by {@link generateDigestMultibase}. Both fields default to
+ * the conventional UNTP/W3C-VC choices when omitted.
+ */
+export interface GenerateDigestMultibaseOptions {
+  /** Hash algorithm. Defaults to `sha2-256`. */
+  algorithm?: HashAlgorithm;
+  /** Multibase encoding for the returned string. Defaults to `base58btc`. */
+  base?: MultibaseEncoding;
+}
+
+const DEFAULT_ALGORITHM: HashAlgorithm = 'sha2-256';
+const DEFAULT_BASE: MultibaseEncoding = 'base58btc';
+
+/**
+ * Hashes the UTF-8 bytes of `content` and returns a multibase-encoded
+ * multihash string suitable for use as `digestMultibase` on a
+ * `RenderTemplate2024` render method (or any other UNTP/W3C-VC field with the
+ * same shape).
+ *
+ * The output is self-describing: the leading character identifies the
+ * multibase encoding, and the prefix bytes identify the hash algorithm. A
+ * verifier can therefore decode and validate the digest without out-of-band
+ * metadata.
+ *
+ * @param content Source string to hash. Encoded as UTF-8 before hashing.
+ * @param opts Optional algorithm and base overrides. See
+ *   {@link GenerateDigestMultibaseOptions} for defaults.
+ * @returns A multibase-encoded multihash string.
+ * @throws If `opts.algorithm` or `opts.base` is not in the
+ *   `@uncefact/untp-utils` allow-list.
+ *
+ * @see https://github.com/multiformats/multihash Multihash specification
+ * @see https://github.com/multiformats/multibase Multibase specification
+ */
+export async function generateDigestMultibase(
+  content: string,
+  opts: GenerateDigestMultibaseOptions = {},
+): Promise<string> {
+  const algorithm = opts.algorithm ?? DEFAULT_ALGORITHM;
+  const base = opts.base ?? DEFAULT_BASE;
+
+  const digest = await MultibaseDigest.fromData(
+    new TextEncoder().encode(content),
+    { algorithm, base },
+  );
+
+  return digest.toString();
+}

--- a/src/digest/multibase.ts
+++ b/src/digest/multibase.ts
@@ -15,8 +15,17 @@ export interface GenerateDigestMultibaseOptions {
   base?: MultibaseEncoding;
 }
 
-const DEFAULT_ALGORITHM: HashAlgorithm = 'sha2-256';
-const DEFAULT_BASE: MultibaseEncoding = 'base58btc';
+/**
+ * Default hash algorithm used by {@link generateDigestMultibase} when the
+ * caller does not supply one. Matches the conventional UNTP/W3C-VC choice.
+ */
+export const DEFAULT_DIGEST_ALGORITHM: HashAlgorithm = 'sha2-256';
+
+/**
+ * Default multibase encoding used by {@link generateDigestMultibase} when the
+ * caller does not supply one. Matches the conventional UNTP/W3C-VC choice.
+ */
+export const DEFAULT_DIGEST_BASE: MultibaseEncoding = 'base58btc';
 
 /**
  * Hashes the UTF-8 bytes of `content` and returns a multibase-encoded
@@ -43,8 +52,8 @@ export async function generateDigestMultibase(
   content: string,
   opts: GenerateDigestMultibaseOptions = {},
 ): Promise<string> {
-  const algorithm = opts.algorithm ?? DEFAULT_ALGORITHM;
-  const base = opts.base ?? DEFAULT_BASE;
+  const algorithm = opts.algorithm ?? DEFAULT_DIGEST_ALGORITHM;
+  const base = opts.base ?? DEFAULT_DIGEST_BASE;
 
   const digest = await MultibaseDigest.fromData(
     new TextEncoder().encode(content),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { generateDigestMultibase } from './digest/multibase';
 import { UnsupportedRenderMethodError } from './errors';
 import { RenderMethodFactory } from './render_methods/factory';
 import { TemplatingEngineFactory } from './templating_engines/factory';
@@ -11,6 +12,10 @@ import { normaliseWhitespace, removeLineBreaks } from './utils';
 
 export * from './errors';
 export * from './types';
+export {
+  generateDigestMultibase,
+  type GenerateDigestMultibaseOptions,
+} from './digest/multibase';
 
 export function constructRenderMethod(
   template: string,
@@ -23,6 +28,83 @@ export function constructRenderMethod(
   const renderMethod = renderMethodFactory.createRenderMethod(renderMethodType);
 
   return renderMethod.construct(cleanedTemplate, extra);
+}
+
+/**
+ * Asynchronous counterpart to {@link constructRenderMethod}. Behaves
+ * identically except that, for `RenderTemplate2024` outputs, it auto-fills
+ * `extra.digestMultibase` from the source `template` bytes when a `url` is
+ * supplied and the caller has not already provided a digest. For all other
+ * render method types and for cases without a `url`, the result matches the
+ * synchronous constructor.
+ *
+ * Gating rationale: `digestMultibase` only adds value when the template is
+ * hosted remotely. The signed credential covers an inline `template` by
+ * itself, so emitting a digest there is at best redundant and at worst a
+ * footgun if the inline content and the recorded digest drift. The presence
+ * of `url` is treated as the caller's declaration of remote intent.
+ *
+ * @param template Source template bytes. The digest, when generated, is
+ *   computed from these bytes prior to whitespace normalisation, so it
+ *   describes the content the caller intends to host at `url`.
+ * @param renderMethodType Render method type to construct.
+ * @param extra Optional metadata, forwarded to the synchronous constructor.
+ *   For `RenderTemplate2024`, supported keys include `name`, `mediaQuery`,
+ *   `url`, `mediaType`, and `digestMultibase`. A caller-supplied
+ *   `digestMultibase` is preserved verbatim.
+ * @returns The constructed render method object.
+ * @throws If `renderMethodType` is not supported, or if the digest
+ *   generation fails (see {@link generateDigestMultibase}).
+ */
+export async function constructRenderMethodAsync(
+  template: string,
+  renderMethodType: RenderMethodType,
+  extra: Record<string, unknown> = {},
+): Promise<RenderMethod> {
+  const resolvedExtra = await resolveExtraWithDigest(
+    template,
+    renderMethodType,
+    extra,
+  );
+
+  return constructRenderMethod(template, renderMethodType, resolvedExtra);
+}
+
+async function resolveExtraWithDigest(
+  template: string,
+  renderMethodType: RenderMethodType,
+  extra: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (renderMethodType !== RenderMethodType.RenderTemplate2024) {
+    return extra;
+  }
+
+  if (!shouldGenerateDigest(template, extra)) {
+    return extra;
+  }
+
+  const digestMultibase = await generateDigestMultibase(template);
+  return { ...extra, digestMultibase };
+}
+
+function shouldGenerateDigest(
+  template: string,
+  extra: Record<string, unknown>,
+): boolean {
+  if (!template) {
+    return false;
+  }
+  if (!isNonEmptyString(extra.url)) {
+    return false;
+  }
+  if (isNonEmptyString(extra.digestMultibase)) {
+    return false;
+  }
+  return true;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value !== '';
 }
 
 export const extractRenderTemplate = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { normaliseWhitespace, removeLineBreaks } from './utils';
 export * from './errors';
 export * from './types';
 export {
+  DEFAULT_DIGEST_ALGORITHM,
+  DEFAULT_DIGEST_BASE,
   generateDigestMultibase,
   type GenerateDigestMultibaseOptions,
 } from './digest/multibase';
@@ -43,6 +45,18 @@ export function constructRenderMethod(
  * itself, so emitting a digest there is at best redundant and at worst a
  * footgun if the inline content and the recorded digest drift. The presence
  * of `url` is treated as the caller's declaration of remote intent.
+ *
+ * Precondition for the URL-hosted case: the bytes the caller intends to host
+ * at `url` must be byte-identical to the `template` argument passed here.
+ * The digest is computed over the raw `template` bytes BEFORE whitespace
+ * normalisation, so it describes the unprocessed input, not the cleaned
+ * value that is also stored in the output's inline `template` field. If a
+ * caller supplies both inline `template` and `url`, the stored inline value
+ * will not hash to `digestMultibase`; a verifier must hash the bytes fetched
+ * from `url`, not the inline `template` field. The intended workflow is to
+ * host the unprocessed input at `url` and treat the inline `template` field
+ * as either absent or a cache that is not the source of truth for the
+ * digest.
  *
  * @param template Source template bytes. The digest, when generated, is
  *   computed from these bytes prior to whitespace normalisation, so it
@@ -75,32 +89,13 @@ async function resolveExtraWithDigest(
   renderMethodType: RenderMethodType,
   extra: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  if (renderMethodType !== RenderMethodType.RenderTemplate2024) {
-    return extra;
-  }
-
-  if (!shouldGenerateDigest(template, extra)) {
-    return extra;
-  }
+  if (renderMethodType !== RenderMethodType.RenderTemplate2024) return extra;
+  if (!template) return extra;
+  if (!isNonEmptyString(extra.url)) return extra;
+  if (isNonEmptyString(extra.digestMultibase)) return extra;
 
   const digestMultibase = await generateDigestMultibase(template);
   return { ...extra, digestMultibase };
-}
-
-function shouldGenerateDigest(
-  template: string,
-  extra: Record<string, unknown>,
-): boolean {
-  if (!template) {
-    return false;
-  }
-  if (!isNonEmptyString(extra.url)) {
-    return false;
-  }
-  if (isNonEmptyString(extra.digestMultibase)) {
-    return false;
-  }
-  return true;
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -856,6 +856,13 @@
     "@typescript-eslint/types" "8.31.1"
     eslint-visitor-keys "^4.2.0"
 
+"@uncefact/untp-utils@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@uncefact/untp-utils/-/untp-utils-0.1.0.tgz#c0c1b019eedb52e297c0abd82722a3183eafe36b"
+  integrity sha512-e70Uz/V/xad9nBcElJKnd66Q0bIX54mLbW8VXCXCvTCCN6UbjUid5y+UA5VC4BinDzT2M5HtFtjCoq/DthZC9A==
+  dependencies:
+    multiformats "^13.3.1"
+
 abbrev@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
@@ -2551,6 +2558,11 @@ ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+multiformats@^13.3.1:
+  version "13.4.2"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-13.4.2.tgz#309ee17d3946db9a6954cf6832aeb2b4b10dd0f3"
+  integrity sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
First release under the trunk-based, tag-triggered model from #26. Bumps `package.json` to `2.1.0` and adds the corresponding `CHANGELOG.md` and `RELEASE_NOTES.md` entries for the digest-multibase helpers.

Once #26 is merged, this PR retargets onto `main`. After merging, pushing `v2.1.0` will trigger the new `Release` workflow to publish to npm.

The two `feat(render-method-2024)` commits are cherry-picks of the work previously reviewed and merged via #25; they bring the digest helpers onto the new trunk.

## Test plan
- [x] All four `yarn` checks pass locally (lint, format, test, build)
- [x] 98 tests across 12 suites pass
- [x] `scripts/check-tag-version-match.mjs` accepts `v2.1.0` against the new `package.json`
- [ ] On merge + tag push: confirm the `Release` workflow runs, the version-match guard passes, and the npm publish via OIDC succeeds