### PR TITLE
test(render-method-2024): assert digestMultibase covers raw bytes, not cleaned template

### DIFF
--- a/src/__tests__/construct-render-method-async.test.ts
+++ b/src/__tests__/construct-render-method-async.test.ts
@@ -97,6 +97,30 @@ describe('constructRenderMethodAsync', () => {
       expect(result.url).toBe(url);
       expect(result.mediaQuery).toBe('print');
     });
+
+    it('hashes the raw template bytes, not the whitespace-normalised template stored in the output', async () => {
+      const rawTemplate = `<div>
+    <h1>{{title}}</h1>
+    <p>{{description}}</p>
+  </div>`;
+
+      const result = (await constructRenderMethodAsync(
+        rawTemplate,
+        RenderMethodType.RenderTemplate2024,
+        { url },
+      )) as RenderTemplate2024;
+
+      expect(result.template).not.toBe(rawTemplate);
+      expect(result.template).not.toContain('\n');
+
+      const parsed = MultibaseDigest.fromString(result.digestMultibase!);
+      await expect(
+        parsed.verify(new TextEncoder().encode(rawTemplate)),
+      ).resolves.toBe(true);
+      await expect(
+        parsed.verify(new TextEncoder().encode(result.template!)),
+      ).resolves.toBe(false);
+    });
   });
 
   describe('WebRenderingTemplate2022', () => {


### PR DESCRIPTION
Adds a regression test that locks the documented contract on `constructRenderMethodAsync`: the `digestMultibase` it generates covers the **raw** template bytes the caller passed in, not the whitespace-normalised template that ends up stored in the output.

The existing test suite covered the two halves separately ("digest verifies against the input template" with a single-line template that has nothing to normalise; "stored template is cleaned" without checking the digest). The new test exercises a multi-line input and asserts the divergence in one place, including the negative case: `parsed.verify(result.template)` MUST be `false`. A future change that switched the hash to operate on the cleaned bytes (to make the digest "consistent" with the stored field) would fail this test.

Test-only change; no functional code touched. No version bump.

## Test plan
- [x] New test passes locally (`yarn test src/__tests__/construct-render-method-async.test.ts` → 10 tests pass)
- [x] Full suite still green
- [x] Lint, format, build clean